### PR TITLE
Add MCP tool to create Homebox locations

### DIFF
--- a/app/src/main/kotlin/com/homebox/mcp/CreateLocationTool.kt
+++ b/app/src/main/kotlin/com/homebox/mcp/CreateLocationTool.kt
@@ -1,0 +1,118 @@
+package com.homebox.mcp
+
+import io.modelcontextprotocol.kotlin.sdk.CallToolResult
+import io.modelcontextprotocol.kotlin.sdk.TextContent
+import io.modelcontextprotocol.kotlin.sdk.Tool
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+
+class CreateLocationTool(private val client: HomeboxClient) {
+	val name: String = "create_location"
+	val description: String =
+		"Create a Homebox location. Provide a single name or a slash-separated path to create nested locations, reusing existing parents when present."
+
+	val inputSchema: Tool.Input = Tool.Input(
+		properties = buildJsonObject {
+			put(
+				"path",
+				buildJsonObject {
+					put("type", "string")
+					put(
+						"description",
+						"The location name or a '/' separated path (e.g., 'Home/Basement/Shelf A'). Matching is case-insensitive and preserves spaces.",
+					)
+				},
+			)
+			put(
+				"description",
+				buildJsonObject {
+					put("type", "string")
+					put(
+						"description",
+						"Optional description applied to the final location created in the path.",
+					)
+				},
+			)
+		},
+		required = listOf("path"),
+	)
+
+	suspend fun execute(arguments: JsonObject): CallToolResult {
+		val rawPath = arguments["path"]?.jsonPrimitive?.contentOrNull?.trim()
+		if (rawPath.isNullOrBlank()) {
+			return CallToolResult(content = listOf(TextContent("Path is required to create a location.")))
+		}
+
+		val description = arguments["description"]
+			?.jsonPrimitive
+			?.contentOrNull
+			?.trim()
+			?.takeIf { it.isNotEmpty() }
+
+		val segments = rawPath
+			.split('/')
+			.map { it.trim() }
+			.filter { it.isNotEmpty() }
+		if (segments.isEmpty()) {
+			return CallToolResult(
+				content = listOf(TextContent("Path must include at least one non-empty location segment.")),
+			)
+		}
+
+		val tree = client.getLocationTree()
+		var currentParentId: String? = null
+		var currentChildren = tree.filterLocations()
+		var currentName: String? = null
+		val createdLocations = mutableListOf<LocationSummary>()
+
+		segments.forEachIndexed { index, segment ->
+			val existing = currentChildren.firstOrNull { it.matchesName(segment) }
+			if (existing != null) {
+				currentParentId = existing.id
+				currentName = existing.name
+				currentChildren = existing.children.filterLocations()
+			} else {
+				val isLast = index == segments.lastIndex
+				val created = client.createLocation(
+					name = segment,
+					parentId = currentParentId,
+					description = if (isLast) description else null,
+				)
+				createdLocations += created
+				currentParentId = created.id
+				currentName = created.name
+				currentChildren = emptyList()
+			}
+		}
+
+		val finalName = currentName ?: segments.last()
+		val fullPath = segments.joinToString(separator = " / ")
+		val message = if (createdLocations.isEmpty()) {
+			"Location \"$finalName\" already exists at path: $fullPath."
+		} else {
+			val createdNames = createdLocations.joinToString(separator = " / ") { it.name }
+			buildString {
+				append("Created ")
+				append(if (createdLocations.size == 1) "location" else "locations")
+				append(':')
+				append(' ')
+				append(createdNames)
+				append(". Full path: ")
+				append(fullPath)
+			}
+		}
+
+		return CallToolResult(content = listOf(TextContent(message)))
+	}
+
+	private fun List<TreeItem>.filterLocations(): List<TreeItem> = filter { it.type.equals(LOCATION_TYPE, ignoreCase = true) }
+
+	private fun TreeItem.matchesName(name: String): Boolean = type.equals(LOCATION_TYPE, ignoreCase = true) && this.name.equals(name, ignoreCase = true)
+
+	private companion object {
+		private const val LOCATION_TYPE = "location"
+	}
+}

--- a/app/src/main/kotlin/com/homebox/mcp/HomeboxMcpServer.kt
+++ b/app/src/main/kotlin/com/homebox/mcp/HomeboxMcpServer.kt
@@ -6,7 +6,8 @@ import io.modelcontextprotocol.kotlin.sdk.server.Server
 import io.modelcontextprotocol.kotlin.sdk.server.ServerOptions
 
 fun createHomeboxServer(client: HomeboxClient): Server {
-	val tool = ListLocationsTool(client)
+	val listTool = ListLocationsTool(client)
+	val createTool = CreateLocationTool(client)
 
 	return Server(
 		Implementation(
@@ -19,8 +20,11 @@ fun createHomeboxServer(client: HomeboxClient): Server {
 			),
 		),
 	).apply {
-		addTool(tool.name, tool.description, tool.inputSchema) { request ->
-			tool.execute(request.arguments)
+		addTool(listTool.name, listTool.description, listTool.inputSchema) { request ->
+			listTool.execute(request.arguments)
+		}
+		addTool(createTool.name, createTool.description, createTool.inputSchema) { request ->
+			createTool.execute(request.arguments)
 		}
 	}
 }

--- a/app/src/test/kotlin/com/homebox/mcp/CreateLocationToolTest.kt
+++ b/app/src/test/kotlin/com/homebox/mcp/CreateLocationToolTest.kt
@@ -1,0 +1,98 @@
+package com.homebox.mcp
+
+import io.modelcontextprotocol.kotlin.sdk.TextContent
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.inOrder
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class CreateLocationToolTest {
+	private val client: HomeboxClient = mock()
+	private val tool = CreateLocationTool(client)
+
+	@Test
+	fun `returns error when path is missing`() =
+		runTest {
+			val result = tool.execute(buildJsonObject {})
+			val text = (result.content.first() as TextContent).text
+
+			assertEquals("Path is required to create a location.", text)
+			verify(client, never()).getLocationTree()
+		}
+
+	@Test
+	fun `reuses existing locations with case insensitive match`() =
+		runTest {
+			whenever(client.getLocationTree()).thenReturn(
+				listOf(TreeItem(id = "1", name = "Home", type = "location")),
+			)
+
+			val result = tool.execute(
+				buildJsonObject {
+					put("path", JsonPrimitive("  home  "))
+				},
+			)
+
+			val text = (result.content.first() as TextContent).text ?: ""
+			assertTrue(text.contains("already exists"))
+			assertTrue(text.contains("Location \"Home\""))
+			verify(client).getLocationTree()
+			verify(client, never()).createLocation(any(), anyOrNull(), anyOrNull())
+		}
+
+	@Test
+	fun `creates missing path segments and reuses parents`() =
+		runTest {
+			whenever(client.getLocationTree()).thenReturn(
+				listOf(
+					TreeItem(
+						id = "root",
+						name = "Home",
+						type = "location",
+					),
+				),
+			)
+
+			val storageSummary = LocationSummary(id = "storage-id", name = "Storage")
+			val shelfSummary = LocationSummary(id = "shelf-id", name = "Shelf A")
+
+			whenever(client.createLocation(name = "storage", parentId = "root", description = null))
+				.thenReturn(storageSummary)
+			whenever(
+				client.createLocation(
+					name = "Shelf A",
+					parentId = storageSummary.id,
+					description = "Deep shelf",
+				),
+			).thenReturn(shelfSummary)
+
+			val result = tool.execute(
+				buildJsonObject {
+					put("path", JsonPrimitive("Home / storage / Shelf A"))
+					put("description", JsonPrimitive("Deep shelf"))
+				},
+			)
+
+			val text = (result.content.first() as TextContent).text ?: ""
+			assertTrue(text.contains("Created locations: Storage / Shelf A."))
+			assertTrue(text.contains("Full path: Home / storage / Shelf A"))
+
+			inOrder(client).apply {
+				verify(client).getLocationTree()
+				verify(client).createLocation(name = "storage", parentId = "root", description = null)
+				verify(client).createLocation(name = "Shelf A", parentId = storageSummary.id, description = "Deep shelf")
+			}
+		}
+}


### PR DESCRIPTION
## Summary
- add an MCP tool that creates locations from a case-insensitive path and reuses existing parents
- extend the Homebox client with helpers for location creation and tree traversal
- register the new tool with the MCP server alongside the existing list tool

## Testing
- ./gradlew -p app ktlintFormat
- ./gradlew -p app test

------
https://chatgpt.com/codex/tasks/task_e_68e9566bfb5883329c7e4ef8055efe1e