### PR TITLE
Add insert item tool to create Homebox items

### DIFF
--- a/app/src/main/kotlin/com/homebox/mcp/HomeboxMcpServer.kt
+++ b/app/src/main/kotlin/com/homebox/mcp/HomeboxMcpServer.kt
@@ -8,6 +8,7 @@ import io.modelcontextprotocol.kotlin.sdk.server.ServerOptions
 fun createHomeboxServer(client: HomeboxClient): Server {
 	val locationsResource = LocationsResource(client)
 	val createTool = CreateLocationTool(client)
+	val insertItemTool = InsertItemTool(client)
 	val itemsResource = ItemsResource(client)
 
 	return Server(
@@ -40,6 +41,9 @@ fun createHomeboxServer(client: HomeboxClient): Server {
 		}
 		addTool(createTool.name, createTool.description, createTool.inputSchema) { request ->
 			createTool.execute(request.arguments)
+		}
+		addTool(insertItemTool.name, insertItemTool.description, insertItemTool.inputSchema) { request ->
+			insertItemTool.execute(request.arguments)
 		}
 	}
 }

--- a/app/src/main/kotlin/com/homebox/mcp/InsertItemTool.kt
+++ b/app/src/main/kotlin/com/homebox/mcp/InsertItemTool.kt
@@ -1,0 +1,240 @@
+package com.homebox.mcp
+
+import io.modelcontextprotocol.kotlin.sdk.CallToolResult
+import io.modelcontextprotocol.kotlin.sdk.TextContent
+import io.modelcontextprotocol.kotlin.sdk.Tool
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.intOrNull
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+
+class InsertItemTool(private val client: HomeboxClient) {
+	val name: String = "insert_item"
+	val description: String =
+		"Create a Homebox item with optional quantity and description. Location may be a location id or a '/' separated path."
+
+	val inputSchema: Tool.Input = Tool.Input(
+		properties = buildJsonObject {
+			put(
+				"name",
+				buildJsonObject {
+					put("type", "string")
+					put("description", "Name of the item to insert. Must be unique within Homebox.")
+				},
+			)
+			put(
+				"quantity",
+				buildJsonObject {
+					put("type", "integer")
+					put("description", "Optional quantity for the item. Defaults to 1 when omitted.")
+					put("default", DEFAULT_QUANTITY)
+					put("minimum", 1)
+				},
+			)
+			put(
+				"location",
+				buildJsonObject {
+					put("type", "string")
+					put(
+						"description",
+						"Location id or '/' separated path where the item should be stored (e.g., 'Home/Kitchen/Shelf A').",
+					)
+				},
+			)
+			put(
+				"description",
+				buildJsonObject {
+					put("type", "string")
+					put("description", "Optional item description.")
+				},
+			)
+		},
+		required = listOf("name", "location"),
+	)
+
+	suspend fun execute(arguments: JsonObject): CallToolResult {
+		val rawName = arguments["name"]?.jsonPrimitive?.contentOrNull?.trim()
+		if (rawName.isNullOrEmpty()) {
+			return CallToolResult(content = listOf(TextContent("Name is required to insert an item.")))
+		}
+
+		val quantityResult = parseQuantity(arguments["quantity"])
+		if (quantityResult is QuantityResult.Error) {
+			return CallToolResult(content = listOf(TextContent(quantityResult.message)))
+		}
+		val quantity = when (quantityResult) {
+			is QuantityResult.Success -> quantityResult.value
+			is QuantityResult.Error -> DEFAULT_QUANTITY
+		}
+
+		val rawLocation = arguments["location"]?.jsonPrimitive?.contentOrNull?.trim()
+		if (rawLocation.isNullOrEmpty()) {
+			return CallToolResult(content = listOf(TextContent("Location is required to insert an item.")))
+		}
+
+		val description = arguments["description"]
+			?.jsonPrimitive
+			?.contentOrNull
+			?.trim()
+			?.takeIf { it.isNotEmpty() }
+
+		val tree = client.getLocationTree()
+		val locationResolution = resolveLocation(rawLocation, tree)
+		if (locationResolution is LocationResolution.Error) {
+			return CallToolResult(content = listOf(TextContent(locationResolution.message)))
+		}
+		val resolvedLocation = locationResolution as LocationResolution.Success
+		val locationId = resolvedLocation.locationId
+
+		val existingItems = client.searchItems(query = rawName, page = 1, pageSize = DUPLICATE_CHECK_PAGE_SIZE)
+		val duplicate = existingItems.items.firstOrNull { it.name.equals(rawName, ignoreCase = true) }
+		if (duplicate != null) {
+			return CallToolResult(
+				content = listOf(
+					TextContent("An item named \"$rawName\" already exists (id: ${duplicate.id}). Provide a unique name."),
+				),
+			)
+		}
+
+		val created = client.createItem(
+			name = rawName,
+			locationId = locationId,
+			description = description,
+			quantity = quantity,
+		)
+
+		val locationPath = resolvedLocation.path
+		val locationDescription = if (locationPath.isNotEmpty()) {
+			locationPath.joinToString(separator = " / ")
+		} else {
+			resolvedLocation.locationId
+		}
+		val finalDescription = created.description?.takeIf { it.isNotBlank() } ?: description
+		val message = buildString {
+			append("Created item \"")
+			append(created.name)
+			append("\"")
+			append(" with quantity ")
+			append(quantity)
+			append(" in location: ")
+			append(locationDescription)
+			finalDescription?.let {
+				append(". Description: ")
+				append(it)
+			}
+		}
+
+		return CallToolResult(content = listOf(TextContent(message)))
+	}
+
+	private fun parseQuantity(element: JsonElement?): QuantityResult {
+		if (element == null) {
+			return QuantityResult.Success(DEFAULT_QUANTITY)
+		}
+
+		val primitive = element as? JsonPrimitive ?: return QuantityResult.Error("Quantity must be an integer value.")
+		val value = primitive.intOrNull ?: return QuantityResult.Error("Quantity must be an integer value.")
+		if (value <= 0) {
+			return QuantityResult.Error("Quantity must be greater than zero.")
+		}
+		return QuantityResult.Success(value)
+	}
+
+	private fun resolveLocation(raw: String, tree: List<TreeItem>): LocationResolution {
+		val trimmed = raw.trim()
+		if (trimmed.isEmpty()) {
+			return LocationResolution.Error("Location is required to insert an item.")
+		}
+
+		findLocationPathById(tree, trimmed)?.let { path ->
+			return LocationResolution.Success(locationId = trimmed, path = path)
+		}
+
+		val segments = trimmed.split('/').map { it.trim() }.filter { it.isNotEmpty() }
+		if (segments.isEmpty()) {
+			return LocationResolution.Error("Location path must include at least one segment.")
+		}
+
+		val matches = findLocationsByPath(tree, segments)
+		if (matches.isEmpty()) {
+			return LocationResolution.Error("No location found for path: ${segments.joinToString(" / ")}.")
+		}
+		if (matches.size > 1) {
+			return LocationResolution.Error(
+				"Multiple locations match path: ${segments.joinToString(" / ")}. Please provide a more specific path or use a location id.",
+			)
+		}
+
+		return LocationResolution.Success(locationId = matches.single().node.id, path = matches.single().path)
+	}
+
+	private fun findLocationsByPath(nodes: List<TreeItem>, segments: List<String>): List<PathMatch> {
+		if (segments.isEmpty()) {
+			return emptyList()
+		}
+
+		var current = nodes.filterLocations().map { PathMatch(node = it, path = listOf(it.name)) }
+		segments.forEachIndexed { index, segment ->
+			current = current.filter { it.node.name.equals(segment, ignoreCase = true) }
+			if (current.isEmpty()) {
+				return emptyList()
+			}
+			if (index != segments.lastIndex) {
+				current = current.flatMap { match ->
+					match.node.children
+						.filterLocations()
+						.map { child -> PathMatch(node = child, path = match.path + child.name) }
+				}
+			}
+		}
+
+		return current
+	}
+
+	private fun findLocationPathById(
+		nodes: List<TreeItem>,
+		targetId: String,
+		currentPath: List<String> = emptyList(),
+	): List<String>? {
+		for (node in nodes) {
+			if (!node.type.equals(LOCATION_TYPE, ignoreCase = true)) {
+				continue
+			}
+			val nextPath = currentPath + node.name
+			if (node.id == targetId) {
+				return nextPath
+			}
+			val childPath = findLocationPathById(node.children, targetId, nextPath)
+			if (childPath != null) {
+				return childPath
+			}
+		}
+		return null
+	}
+
+	private fun List<TreeItem>.filterLocations(): List<TreeItem> = filter { it.type.equals(LOCATION_TYPE, ignoreCase = true) }
+
+	private sealed interface QuantityResult {
+		data class Success(val value: Int) : QuantityResult
+
+		data class Error(val message: String) : QuantityResult
+	}
+
+	private sealed interface LocationResolution {
+		data class Success(val locationId: String, val path: List<String>) : LocationResolution
+
+		data class Error(val message: String) : LocationResolution
+	}
+
+	private data class PathMatch(val node: TreeItem, val path: List<String>)
+
+	private companion object {
+		private const val DEFAULT_QUANTITY = 1
+		private const val LOCATION_TYPE = "location"
+		private const val DUPLICATE_CHECK_PAGE_SIZE = 25
+	}
+}

--- a/app/src/test/kotlin/com/homebox/mcp/InsertItemToolTest.kt
+++ b/app/src/test/kotlin/com/homebox/mcp/InsertItemToolTest.kt
@@ -1,0 +1,177 @@
+package com.homebox.mcp
+
+import io.modelcontextprotocol.kotlin.sdk.TextContent
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class InsertItemToolTest {
+	private val client: HomeboxClient = mock()
+	private val tool = InsertItemTool(client)
+
+	@Test
+	fun `returns error when name is missing`() =
+		runTest {
+			val result = tool.execute(
+				buildJsonObject {
+					put("location", JsonPrimitive("Home/Kitchen"))
+				},
+			)
+
+			val text = (result.content.first() as TextContent).text
+			assertEquals("Name is required to insert an item.", text)
+			verify(client, never()).getLocationTree()
+		}
+
+	@Test
+	fun `returns error when quantity is invalid`() =
+		runTest {
+			val result = tool.execute(
+				buildJsonObject {
+					put("name", JsonPrimitive("Hammer"))
+					put("quantity", JsonPrimitive("many"))
+					put("location", JsonPrimitive("Home/Kitchen"))
+				},
+			)
+
+			val text = (result.content.first() as TextContent).text
+			assertEquals("Quantity must be an integer value.", text)
+			verify(client, never()).getLocationTree()
+		}
+
+	@Test
+	fun `returns error when location path is unknown`() =
+		runTest {
+			whenever(client.getLocationTree()).thenReturn(
+				listOf(TreeItem(id = "root", name = "Home", type = "location")),
+			)
+
+			val result = tool.execute(
+				buildJsonObject {
+					put("name", JsonPrimitive("Hammer"))
+					put("location", JsonPrimitive("Home/Basement"))
+				},
+			)
+
+			val text = (result.content.first() as TextContent).text
+			assertTrue(text?.contains("No location found") == true)
+			verify(client).getLocationTree()
+			verify(client, never()).searchItems(any(), any(), any())
+		}
+
+	@Test
+	fun `returns error when duplicate item is found`() =
+		runTest {
+			val tree = listOf(
+				TreeItem(
+					id = "root",
+					name = "Home",
+					type = "location",
+					children = listOf(
+						TreeItem(id = "kitchen", name = "Kitchen", type = "location"),
+					),
+				),
+			)
+			whenever(client.getLocationTree()).thenReturn(tree)
+			whenever(client.searchItems(query = eq("Hammer"), page = eq(1), pageSize = eq(25))).thenReturn(
+				ItemPage(
+					items = listOf(
+						ItemSummary(
+							id = "item-1",
+							name = "Hammer",
+							description = "Steel hammer",
+							quantity = 1,
+							location = LocationSummary(id = "kitchen", name = "Kitchen"),
+						),
+					),
+					page = 1,
+					pageSize = 25,
+					total = 1,
+				),
+			)
+
+			val result = tool.execute(
+				buildJsonObject {
+					put("name", JsonPrimitive("Hammer"))
+					put("location", JsonPrimitive("Home/Kitchen"))
+				},
+			)
+
+			val text = (result.content.first() as TextContent).text
+			assertTrue(text?.contains("already exists") == true)
+			verify(client).getLocationTree()
+			verify(client).searchItems(query = eq("Hammer"), page = eq(1), pageSize = eq(25))
+			verify(client, never()).createItem(any(), any(), any(), any())
+		}
+
+	@Test
+	fun `creates item when location path matches`() =
+		runTest {
+			val tree = listOf(
+				TreeItem(
+					id = "root",
+					name = "Home",
+					type = "location",
+					children = listOf(
+						TreeItem(
+							id = "kitchen",
+							name = "Kitchen",
+							type = "location",
+							children = listOf(
+								TreeItem(id = "cupboard", name = "Cupboard A", type = "location"),
+							),
+						),
+					),
+				),
+			)
+			whenever(client.getLocationTree()).thenReturn(tree)
+			whenever(client.searchItems(query = eq("Hammer"), page = eq(1), pageSize = eq(25))).thenReturn(
+				ItemPage(items = emptyList(), page = 1, pageSize = 25, total = 0),
+			)
+			whenever(
+				client.createItem(
+					name = eq("Hammer"),
+					locationId = eq("cupboard"),
+					description = eq("Steel hammer"),
+					quantity = eq(2),
+				),
+			).thenReturn(
+				ItemSummary(
+					id = "item-2",
+					name = "Hammer",
+					description = "Steel hammer",
+					quantity = 2,
+					location = LocationSummary(id = "cupboard", name = "Cupboard A"),
+				),
+			)
+
+			val result = tool.execute(
+				buildJsonObject {
+					put("name", JsonPrimitive("Hammer"))
+					put("quantity", JsonPrimitive(2))
+					put("location", JsonPrimitive("Home/Kitchen/Cupboard A"))
+					put("description", JsonPrimitive("Steel hammer"))
+				},
+			)
+
+			val text = (result.content.first() as TextContent).text ?: ""
+			assertTrue(text.contains("Created item \"Hammer\""))
+			assertTrue(text.contains("quantity 2"))
+			assertTrue(text.contains("Home / Kitchen / Cupboard A"))
+			assertTrue(text.contains("Description: Steel hammer"))
+			verify(client).searchItems(query = eq("Hammer"), page = eq(1), pageSize = eq(25))
+			verify(client).createItem(name = eq("Hammer"), locationId = eq("cupboard"), description = eq("Steel hammer"), quantity = eq(2))
+		}
+}


### PR DESCRIPTION
## Summary
- add an insert_item tool that validates quantity, resolves location paths, and prevents duplicates before creating items
- extend the Homebox client with search and create item helpers consumed by the new tool and server registration
- exercise the new APIs with unit tests covering success and error flows

## Testing
- ./gradlew ktlintFormat
- ./gradlew check --parallel --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68f0040b6dd483328f1f2a37678364a6