### PR TITLE
Add insert item tool for Homebox items

### DIFF
--- a/app/src/main/kotlin/com/homebox/mcp/HomeboxClient.kt
+++ b/app/src/main/kotlin/com/homebox/mcp/HomeboxClient.kt
@@ -5,6 +5,7 @@ import io.ktor.client.request.accept
 import io.ktor.client.request.get
 import io.ktor.client.request.header
 import io.ktor.client.request.parameter
+import io.ktor.client.request.patch
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.client.statement.bodyAsText
@@ -67,8 +68,13 @@ class HomeboxClient(
 		return json.decodeFromString(LocationSummary.serializer(), payload)
 	}
 
-	suspend fun listItems(locationIds: List<String>? = null, pageSize: Int = 100): ItemPage {
+	suspend fun listItems(
+		page: Int = 1,
+		locationIds: List<String>? = null,
+		pageSize: Int = 100,
+	): ItemPage {
 		val response = httpClient.get("$baseUrl/v1/items") {
+			parameter("page", page)
 			parameter("pageSize", pageSize)
 			locationIds?.forEach { parameter("locations", it) }
 			accept(ContentType.Application.Json)
@@ -87,6 +93,42 @@ class HomeboxClient(
 
 		val payload = response.bodyAsText()
 		return json.decodeFromString(LocationDetails.serializer(), payload)
+	}
+
+	suspend fun createItem(
+		name: String,
+		locationId: String,
+		description: String? = null,
+	): ItemSummary {
+		require(name.isNotBlank()) { "Item name must not be blank" }
+		require(locationId.isNotBlank()) { "Location ID must not be blank" }
+
+		val response = httpClient.post("$baseUrl/v1/items") {
+			accept(ContentType.Application.Json)
+			header(HttpHeaders.ContentType, ContentType.Application.Json)
+			header(HttpHeaders.Authorization, "Bearer $apiToken")
+			setBody(
+				ItemCreateRequest(
+					name = name,
+					description = description,
+					locationId = locationId,
+				),
+			)
+		}
+
+		val payload = response.bodyAsText()
+		return json.decodeFromString(ItemSummary.serializer(), payload)
+	}
+
+	suspend fun updateItemQuantity(itemId: String, quantity: Int) {
+		require(itemId.isNotBlank()) { "Item ID must not be blank" }
+
+		httpClient.patch("$baseUrl/v1/items/$itemId") {
+			accept(ContentType.Application.Json)
+			header(HttpHeaders.ContentType, ContentType.Application.Json)
+			header(HttpHeaders.Authorization, "Bearer $apiToken")
+			setBody(ItemPatchRequest(quantity = quantity))
+		}
 	}
 
 	private companion object {
@@ -123,6 +165,20 @@ private data class LocationCreateRequest(
 	val name: String,
 	val description: String? = null,
 	val parentId: String? = null,
+)
+
+@Serializable
+private data class ItemCreateRequest(
+	val name: String,
+	val description: String? = null,
+	val locationId: String,
+	val labelIds: List<String>? = null,
+	val parentId: String? = null,
+)
+
+@Serializable
+private data class ItemPatchRequest(
+	val quantity: Int? = null,
 )
 
 @Serializable

--- a/app/src/main/kotlin/com/homebox/mcp/HomeboxMcpServer.kt
+++ b/app/src/main/kotlin/com/homebox/mcp/HomeboxMcpServer.kt
@@ -8,6 +8,7 @@ import io.modelcontextprotocol.kotlin.sdk.server.ServerOptions
 fun createHomeboxServer(client: HomeboxClient): Server {
 	val locationsResource = LocationsResource(client)
 	val createTool = CreateLocationTool(client)
+	val insertItemTool = InsertItemTool(client)
 	val itemsResource = ItemsResource(client)
 
 	return Server(
@@ -40,6 +41,9 @@ fun createHomeboxServer(client: HomeboxClient): Server {
 		}
 		addTool(createTool.name, createTool.description, createTool.inputSchema) { request ->
 			createTool.execute(request.arguments)
+		}
+		addTool(insertItemTool.name, insertItemTool.description, insertItemTool.inputSchema) { request ->
+			insertItemTool.execute(request.arguments)
 		}
 	}
 }

--- a/app/src/main/kotlin/com/homebox/mcp/InsertItemTool.kt
+++ b/app/src/main/kotlin/com/homebox/mcp/InsertItemTool.kt
@@ -1,0 +1,256 @@
+package com.homebox.mcp
+
+import io.modelcontextprotocol.kotlin.sdk.CallToolResult
+import io.modelcontextprotocol.kotlin.sdk.TextContent
+import io.modelcontextprotocol.kotlin.sdk.Tool
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.intOrNull
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+
+class InsertItemTool(private val client: HomeboxClient) {
+	val name: String = "insert_item"
+	val description: String =
+		"Insert an item into Homebox, creating it at the specified location path or location ID."
+
+	val inputSchema: Tool.Input = Tool.Input(
+		properties = buildJsonObject {
+			put(
+				"name",
+				buildJsonObject {
+					put("type", "string")
+					put("description", "Name of the item. Must be unique across all items.")
+				},
+			)
+			put(
+				"location",
+				buildJsonObject {
+					put("type", "string")
+					put(
+						"description",
+						"Target location expressed either as a location ID or as a '/' separated path (e.g., 'Home/Kitchen/Shelf A').",
+					)
+				},
+			)
+			put(
+				"quantity",
+				buildJsonObject {
+					put("type", "integer")
+					put("description", "Optional quantity. Defaults to 1 when omitted.")
+				},
+			)
+			put(
+				"description",
+				buildJsonObject {
+					put("type", "string")
+					put("description", "Optional description for the item.")
+				},
+			)
+		},
+		required = listOf("name", "location"),
+	)
+
+	suspend fun execute(arguments: JsonObject): CallToolResult {
+		val rawName = arguments["name"]?.jsonPrimitive?.contentOrNull?.trim()
+		if (rawName.isNullOrEmpty()) {
+			return CallToolResult(
+				content = listOf(TextContent("Item name is required and must not be blank.")),
+			)
+		}
+
+		val rawLocation = arguments["location"]?.jsonPrimitive?.contentOrNull?.trim()
+		if (rawLocation.isNullOrEmpty()) {
+			return CallToolResult(
+				content = listOf(TextContent("Location is required and must not be blank.")),
+			)
+		}
+
+		val quantityResult = parseQuantity(arguments["quantity"])
+		if (quantityResult is QuantityResult.Error) {
+			return CallToolResult(content = listOf(TextContent(quantityResult.message)))
+		}
+		val quantity = (quantityResult as QuantityResult.Value).quantity
+
+		val description = arguments["description"]?.jsonPrimitive?.contentOrNull?.trim()?.takeIf { it.isNotEmpty() }
+
+		when (val locationResult = resolveLocation(rawLocation)) {
+			is LocationResult.Error -> {
+				return CallToolResult(content = listOf(TextContent(locationResult.message)))
+			}
+			is LocationResult.Value -> {
+				if (!isNameUnique(rawName)) {
+					return CallToolResult(
+						content = listOf(TextContent("An item named \"$rawName\" already exists.")),
+					)
+				}
+
+				val created = client.createItem(
+					name = rawName,
+					locationId = locationResult.location.id,
+					description = description,
+				)
+
+				if (quantity != DEFAULT_QUANTITY) {
+					client.updateItemQuantity(created.id, quantity)
+				}
+
+				val pathDisplay = locationResult.location.path.joinToString(separator = " / ")
+				val quantityDisplay =
+					quantity.takeIf { it != DEFAULT_QUANTITY }
+						?: (created.quantity ?: DEFAULT_QUANTITY)
+				val message = buildString {
+					append("Created item \"")
+					append(created.name)
+					append("\" with quantity ")
+					append(quantityDisplay)
+					append(" at location ")
+					append(pathDisplay)
+					append('.')
+				}
+
+				return CallToolResult(content = listOf(TextContent(message)))
+			}
+		}
+
+		error("Unreachable")
+	}
+
+	private fun parseQuantity(element: JsonElement?): QuantityResult {
+		if (element == null) {
+			return QuantityResult.Value(DEFAULT_QUANTITY)
+		}
+
+		val primitive = element.jsonPrimitive
+		val value = primitive.intOrNull
+			?: return QuantityResult.Error("Quantity must be a positive integer when provided.")
+		if (value <= 0) {
+			return QuantityResult.Error("Quantity must be a positive integer when provided.")
+		}
+		return QuantityResult.Value(value)
+	}
+
+	private suspend fun resolveLocation(reference: String): LocationResult {
+		val cleaned = reference.trim().trim('/')
+		if (cleaned.isEmpty()) {
+			return LocationResult.Error("Location is required and must not be blank.")
+		}
+
+		val tree = client.getLocationTree()
+		val segments = cleaned.split('/').map { it.trim() }.filter { it.isNotEmpty() }
+
+		findLocationById(tree, cleaned)?.let { return LocationResult.Value(it) }
+
+		if (segments.isEmpty()) {
+			return LocationResult.Error("Unable to resolve location: $reference")
+		}
+
+		val matches = findLocationsByPath(tree.filterLocations(), segments, 0, emptyList())
+		if (matches.isEmpty()) {
+			return LocationResult.Error("Unable to resolve location: $reference")
+		}
+		if (matches.size > 1) {
+			val options = matches.joinToString(separator = "; ") {
+				it.path.joinToString(separator = " / ")
+			}
+			return LocationResult.Error("Location path is ambiguous. Possible matches: $options")
+		}
+		return LocationResult.Value(matches.first())
+	}
+
+	private fun List<TreeItem>.filterLocations(): List<TreeItem> = filter { it.type.equals(LOCATION_TYPE, ignoreCase = true) }
+
+	private fun findLocationById(
+		nodes: List<TreeItem>,
+		targetId: String,
+		path: List<String> = emptyList(),
+	): ResolvedLocation? {
+		nodes.forEach { node ->
+			if (!node.type.equals(LOCATION_TYPE, ignoreCase = true)) {
+				return@forEach
+			}
+			val currentPath = path + node.name
+			if (node.id == targetId) {
+				return ResolvedLocation(node.id, currentPath)
+			}
+			findLocationById(node.children, targetId, currentPath)?.let { return it }
+		}
+		return null
+	}
+
+	private fun findLocationsByPath(
+		nodes: List<TreeItem>,
+		segments: List<String>,
+		depth: Int,
+		path: List<String>,
+	): List<ResolvedLocation> {
+		if (depth >= segments.size) {
+			return emptyList()
+		}
+
+		val segment = segments[depth]
+		val matches = mutableListOf<ResolvedLocation>()
+
+		nodes.forEach { node ->
+			if (!node.type.equals(LOCATION_TYPE, ignoreCase = true)) {
+				return@forEach
+			}
+			if (!node.name.equals(segment, ignoreCase = true)) {
+				return@forEach
+			}
+
+			val currentPath = path + node.name
+			if (depth == segments.lastIndex) {
+				matches += ResolvedLocation(node.id, currentPath)
+			} else {
+				matches += findLocationsByPath(
+					node.children.filterLocations(),
+					segments,
+					depth + 1,
+					currentPath,
+				)
+			}
+		}
+
+		return matches
+	}
+
+	private suspend fun isNameUnique(name: String): Boolean {
+		var page = 1
+		val normalized = name.lowercase()
+
+		while (true) {
+			val result = client.listItems(page = page, pageSize = ITEM_PAGE_SIZE)
+			if (result.items.any { it.name.lowercase() == normalized }) {
+				return false
+			}
+
+			if (result.page * result.pageSize >= result.total) {
+				return true
+			}
+			page += 1
+		}
+	}
+
+	private data class ResolvedLocation(val id: String, val path: List<String>)
+
+	private sealed interface QuantityResult {
+		data class Value(val quantity: Int) : QuantityResult
+
+		data class Error(val message: String) : QuantityResult
+	}
+
+	private sealed interface LocationResult {
+		data class Value(val location: ResolvedLocation) : LocationResult
+
+		data class Error(val message: String) : LocationResult
+	}
+
+	private companion object {
+		private const val DEFAULT_QUANTITY = 1
+		private const val ITEM_PAGE_SIZE = 100
+		private const val LOCATION_TYPE = "location"
+	}
+}

--- a/app/src/test/kotlin/com/homebox/mcp/InsertItemToolTest.kt
+++ b/app/src/test/kotlin/com/homebox/mcp/InsertItemToolTest.kt
@@ -1,0 +1,203 @@
+package com.homebox.mcp
+
+import io.modelcontextprotocol.kotlin.sdk.TextContent
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.reset
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+class InsertItemToolTest {
+	private val client: HomeboxClient = mock()
+
+	@BeforeEach
+	fun resetMocks() {
+		reset(client)
+	}
+
+	@Test
+	fun `creates item with default quantity when omitted`() =
+		runTest {
+			whenever(client.getLocationTree()).thenReturn(
+				listOf(
+					TreeItem(
+						id = "home",
+						name = "Home",
+						type = "location",
+						children = listOf(
+							TreeItem(
+								id = "kitchen",
+								name = "Kitchen",
+								type = "location",
+							),
+						),
+					),
+				),
+			)
+			whenever(client.listItems(page = any(), locationIds = anyOrNull(), pageSize = any())).thenReturn(
+				ItemPage(items = emptyList(), page = 1, pageSize = 100, total = 0),
+			)
+			whenever(
+				client.createItem(
+					name = eq("Spoon"),
+					locationId = eq("kitchen"),
+					description = eq("Stainless"),
+				),
+			).thenReturn(
+				ItemSummary(
+					id = "item-1",
+					name = "Spoon",
+					description = "Stainless",
+					quantity = 1,
+					location = LocationSummary(id = "kitchen", name = "Kitchen", description = null),
+				),
+			)
+
+			val tool = InsertItemTool(client)
+			val result = tool.execute(
+				buildJsonObject {
+					put("name", "Spoon")
+					put("location", "Home/Kitchen")
+					put("description", "Stainless")
+				},
+			)
+
+			val message = (result.content.first() as TextContent).text ?: error("Expected text content")
+			assertEquals("Created item \"Spoon\" with quantity 1 at location Home / Kitchen.", message)
+			verify(client, never()).updateItemQuantity(any(), any())
+		}
+
+	@Test
+	fun `creates item with explicit quantity`() =
+		runTest {
+			whenever(client.getLocationTree()).thenReturn(
+				listOf(
+					TreeItem(
+						id = "garage",
+						name = "Garage",
+						type = "location",
+					),
+				),
+			)
+			whenever(client.listItems(page = any(), locationIds = anyOrNull(), pageSize = any())).thenReturn(
+				ItemPage(items = emptyList(), page = 1, pageSize = 100, total = 0),
+			)
+			whenever(
+				client.createItem(
+					name = eq("Wrench"),
+					locationId = eq("garage"),
+					description = eq(null),
+				),
+			).thenReturn(
+				ItemSummary(
+					id = "item-2",
+					name = "Wrench",
+					description = null,
+					quantity = 1,
+					location = LocationSummary(id = "garage", name = "Garage", description = null),
+				),
+			)
+
+			val tool = InsertItemTool(client)
+			val result = tool.execute(
+				buildJsonObject {
+					put("name", "Wrench")
+					put("location", "garage")
+					put("quantity", 4)
+				},
+			)
+
+			verify(client).updateItemQuantity("item-2", 4)
+			val message = (result.content.first() as TextContent).text ?: error("Expected text content")
+			assertEquals("Created item \"Wrench\" with quantity 4 at location Garage.", message)
+		}
+
+	@Test
+	fun `returns error when duplicate name exists`() =
+		runTest {
+			whenever(client.getLocationTree()).thenReturn(
+				listOf(
+					TreeItem(
+						id = "home",
+						name = "Home",
+						type = "location",
+					),
+				),
+			)
+			whenever(client.listItems(page = eq(1), locationIds = anyOrNull(), pageSize = any())).thenReturn(
+				ItemPage(
+					items = listOf(
+						ItemSummary(
+							id = "existing",
+							name = "Lamp",
+							description = null,
+							quantity = 1,
+							location = null,
+						),
+					),
+					page = 1,
+					pageSize = 100,
+					total = 1,
+				),
+			)
+
+			val tool = InsertItemTool(client)
+			val result = tool.execute(
+				buildJsonObject {
+					put("name", "Lamp")
+					put("location", "home")
+				},
+			)
+
+			val message = (result.content.first() as TextContent).text ?: error("Expected text content")
+			assertEquals("An item named \"Lamp\" already exists.", message)
+			verify(client, never()).createItem(any(), any(), anyOrNull())
+		}
+
+	@Test
+	fun `returns error when location path is ambiguous`() =
+		runTest {
+			whenever(client.getLocationTree()).thenReturn(
+				listOf(
+					TreeItem(
+						id = "home",
+						name = "Home",
+						type = "location",
+						children = listOf(
+							TreeItem(
+								id = "closet-upper",
+								name = "Closet",
+								type = "location",
+							),
+							TreeItem(
+								id = "closet-lower",
+								name = "Closet",
+								type = "location",
+							),
+						),
+					),
+				),
+			)
+
+			val tool = InsertItemTool(client)
+			val result = tool.execute(
+				buildJsonObject {
+					put("name", "Shoes")
+					put("location", "Home/Closet")
+				},
+			)
+
+			val message = (result.content.first() as TextContent).text ?: error("Expected text content")
+			assertTrue(message.startsWith("Location path is ambiguous."))
+		}
+}

--- a/app/src/test/kotlin/com/homebox/mcp/ItemsResourceTest.kt
+++ b/app/src/test/kotlin/com/homebox/mcp/ItemsResourceTest.kt
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
@@ -28,7 +29,7 @@ class ItemsResourceTest {
 	@Test
 	fun `read without query returns items with cached location paths`() =
 		runTest {
-			whenever(client.listItems(locationIds = null, pageSize = 100)).thenReturn(
+			whenever(client.listItems(page = 1, locationIds = null, pageSize = 100)).thenReturn(
 				ItemPage(
 					items = listOf(
 						ItemSummary(
@@ -61,7 +62,7 @@ class ItemsResourceTest {
 
 			val result = resource.read(ReadResourceRequest("resource://homebox/items", buildJsonObject { }))
 
-			verify(client).listItems(locationIds = null, pageSize = 100)
+			verify(client).listItems(page = 1, locationIds = null, pageSize = 100)
 			verify(client).getLocation("loc-1")
 			verify(client).getLocation("loc-0")
 			verify(client).getLocation("root")
@@ -90,7 +91,7 @@ class ItemsResourceTest {
 					),
 				),
 			)
-			whenever(client.listItems(locationIds = listOf("loc-2"), pageSize = 100)).thenReturn(
+			whenever(client.listItems(page = 1, locationIds = listOf("loc-2"), pageSize = 100)).thenReturn(
 				ItemPage(
 					items = listOf(
 						ItemSummary(
@@ -113,7 +114,7 @@ class ItemsResourceTest {
 			val result = resource.read(request)
 
 			verify(client).getLocationTree()
-			verify(client).listItems(locationIds = listOf("loc-2"), pageSize = 100)
+			verify(client).listItems(page = 1, locationIds = listOf("loc-2"), pageSize = 100)
 
 			val contents = result.contents.single() as TextResourceContents
 			val payload = requireNotNull(contents.text)
@@ -136,7 +137,7 @@ class ItemsResourceTest {
 			val result = resource.read(request)
 
 			verify(client).getLocationTree()
-			verify(client, never()).listItems(any(), any())
+			verify(client, never()).listItems(any(), anyOrNull(), any())
 
 			val contents = result.contents.single() as TextResourceContents
 			val payload = requireNotNull(contents.text)


### PR DESCRIPTION
## Summary
- add client support for creating items and updating their quantity
- implement an `insert_item` tool that resolves locations, enforces uniqueness, and patches quantities when needed
- cover the new behavior with unit tests and adjust existing item resource tests for the updated client API

## Testing
- ./gradlew ktlintFormat --console=plain
- ./gradlew check --parallel --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68f0040b6dd483328f1f2a37678364a6