### PR TITLE
Add insert item tool

### DIFF
--- a/app/src/main/kotlin/com/homebox/mcp/HomeboxMcpServer.kt
+++ b/app/src/main/kotlin/com/homebox/mcp/HomeboxMcpServer.kt
@@ -8,6 +8,7 @@ import io.modelcontextprotocol.kotlin.sdk.server.ServerOptions
 fun createHomeboxServer(client: HomeboxClient): Server {
 	val locationsResource = LocationsResource(client)
 	val createTool = CreateLocationTool(client)
+	val insertItemTool = InsertItemTool(client)
 	val itemsResource = ItemsResource(client)
 
 	return Server(
@@ -40,6 +41,9 @@ fun createHomeboxServer(client: HomeboxClient): Server {
 		}
 		addTool(createTool.name, createTool.description, createTool.inputSchema) { request ->
 			createTool.execute(request.arguments)
+		}
+		addTool(insertItemTool.name, insertItemTool.description, insertItemTool.inputSchema) { request ->
+			insertItemTool.execute(request.arguments)
 		}
 	}
 }

--- a/app/src/main/kotlin/com/homebox/mcp/InsertItemTool.kt
+++ b/app/src/main/kotlin/com/homebox/mcp/InsertItemTool.kt
@@ -1,0 +1,158 @@
+package com.homebox.mcp
+
+import io.modelcontextprotocol.kotlin.sdk.CallToolResult
+import io.modelcontextprotocol.kotlin.sdk.TextContent
+import io.modelcontextprotocol.kotlin.sdk.Tool
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.intOrNull
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+
+class InsertItemTool(private val client: HomeboxClient) {
+	val name: String = "insert_item"
+	val description: String =
+		"Insert a new Homebox item given a unique name, quantity, location, and optional description."
+
+	val inputSchema: Tool.Input = Tool.Input(
+		properties = buildJsonObject {
+			put(
+				"name",
+				buildJsonObject {
+					put("type", "string")
+					put("description", "The unique name of the item to create.")
+				},
+			)
+			put(
+				"quantity",
+				buildJsonObject {
+					put("type", "integer")
+					put("description", "Optional quantity for the item (defaults to 1).")
+				},
+			)
+			put(
+				"location",
+				buildJsonObject {
+					put("type", "string")
+					put(
+						"description",
+						"Location ID or '/' separated absolute path (e.g., 'Home/Kitchen/Shelf A').",
+					)
+				},
+			)
+			put(
+				"description",
+				buildJsonObject {
+					put("type", "string")
+					put("description", "Optional description for the item.")
+				},
+			)
+		},
+		required = listOf("name", "location"),
+	)
+
+	suspend fun execute(arguments: JsonObject): CallToolResult {
+		val rawName = arguments["name"]?.jsonPrimitive?.contentOrNull?.trim()
+		if (rawName.isNullOrBlank()) {
+			return errorResult("Item name is required to insert an item.")
+		}
+
+		val rawLocation = arguments["location"]?.jsonPrimitive?.contentOrNull?.trim()
+		if (rawLocation.isNullOrBlank()) {
+			return errorResult("Location is required to insert an item.")
+		}
+
+		val quantity = arguments["quantity"]?.jsonPrimitive?.intOrNull ?: DEFAULT_QUANTITY
+		if (quantity <= 0) {
+			return errorResult("Quantity must be a positive integer.")
+		}
+
+		val description = arguments["description"]
+			?.jsonPrimitive
+			?.contentOrNull
+			?.trim()
+			?.takeIf { it.isNotEmpty() }
+
+		val existingItems = client.listItems(query = rawName, pageSize = DUPLICATE_CHECK_PAGE_SIZE)
+		val duplicateExists = existingItems.items.any { it.name.equals(rawName, ignoreCase = true) }
+		if (duplicateExists) {
+			return errorResult("An item named \"$rawName\" already exists. Choose a different name.")
+		}
+
+		val locationTree = client.getLocationTree()
+		val resolvedLocation = resolveLocation(rawLocation, locationTree)
+			?: return errorResult("Location '$rawLocation' was not found.")
+
+		val createdItem = client.createItem(
+			name = rawName,
+			locationId = resolvedLocation.id,
+			description = description,
+		)
+
+		if (quantity != DEFAULT_QUANTITY) {
+			client.updateItemQuantity(createdItem.id, quantity)
+		}
+
+		val locationPath = resolvedLocation.path.joinToString(separator = " / ")
+		val message = buildString {
+			append("Created item \"")
+			append(createdItem.name)
+			append("\" at location: ")
+			append(locationPath)
+			append('.')
+			if (quantity != DEFAULT_QUANTITY) {
+				append(' ')
+				append("Quantity set to ")
+				append(quantity)
+				append('.')
+			} else {
+				append(' ')
+				append("Quantity defaults to ")
+				append(DEFAULT_QUANTITY)
+				append('.')
+			}
+		}
+
+		return CallToolResult(content = listOf(TextContent(message)))
+	}
+
+	private fun resolveLocation(rawLocation: String, tree: List<TreeItem>): ResolvedLocation? {
+		val flattened = mutableListOf<ResolvedLocation>()
+
+		fun traverse(node: TreeItem, path: List<String>) {
+			if (!node.type.equals(LOCATION_TYPE, ignoreCase = true)) {
+				return
+			}
+			val currentPath = path + node.name
+			flattened += ResolvedLocation(id = node.id, path = currentPath)
+			node.children.forEach { traverse(it, currentPath) }
+		}
+
+		tree.forEach { traverse(it, emptyList()) }
+
+		flattened.firstOrNull { it.id == rawLocation }?.let { return it }
+
+		val segments = rawLocation.split('/').map { it.trim() }.filter { it.isNotEmpty() }
+		if (segments.isEmpty()) {
+			return null
+		}
+
+		return flattened.firstOrNull { resolved ->
+			if (resolved.path.size != segments.size) {
+				return@firstOrNull false
+			}
+			resolved.path.zip(segments).all { (actual, expected) -> actual.equals(expected, ignoreCase = true) }
+		}
+	}
+
+	private fun errorResult(message: String): CallToolResult = CallToolResult(content = listOf(TextContent(message)))
+
+	private data class ResolvedLocation(val id: String, val path: List<String>)
+
+	private companion object {
+		private const val LOCATION_TYPE = "location"
+		private const val DEFAULT_QUANTITY = 1
+		private const val DUPLICATE_CHECK_PAGE_SIZE = 50
+	}
+}

--- a/app/src/test/kotlin/com/homebox/mcp/InsertItemToolTest.kt
+++ b/app/src/test/kotlin/com/homebox/mcp/InsertItemToolTest.kt
@@ -1,0 +1,203 @@
+package com.homebox.mcp
+
+import io.modelcontextprotocol.kotlin.sdk.TextContent
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class InsertItemToolTest {
+	private val client: HomeboxClient = mock()
+	private val tool = InsertItemTool(client)
+
+	@Test
+	fun `returns error when name missing`() =
+		runTest {
+			val result = tool.execute(
+				buildJsonObject {
+					put("location", JsonPrimitive("Home/Kitchen"))
+				},
+			)
+
+			val text = (result.content.first() as TextContent).text.orEmpty()
+			assertEquals("Item name is required to insert an item.", text)
+			verify(client, never()).listItems(anyOrNull(), anyOrNull(), any())
+		}
+
+	@Test
+	fun `returns error when location missing`() =
+		runTest {
+			val result = tool.execute(
+				buildJsonObject {
+					put("name", JsonPrimitive("Hammer"))
+				},
+			)
+
+			val text = (result.content.first() as TextContent).text.orEmpty()
+			assertEquals("Location is required to insert an item.", text)
+			verify(client, never()).listItems(anyOrNull(), anyOrNull(), any())
+		}
+
+	@Test
+	fun `returns error when duplicate name exists`() =
+		runTest {
+			whenever(client.listItems(query = eq("Hammer"), locationIds = anyOrNull(), pageSize = eq(50)))
+				.thenReturn(
+					ItemPage(
+						items = listOf(
+							ItemSummary(
+								id = "item-1",
+								name = "HAMMER",
+								description = null,
+								quantity = 1,
+								location = null,
+							),
+						),
+						page = 1,
+						pageSize = 50,
+						total = 1,
+					),
+				)
+
+			val result = tool.execute(
+				buildJsonObject {
+					put("name", JsonPrimitive("Hammer"))
+					put("location", JsonPrimitive("Home/Garage"))
+				},
+			)
+
+			val text = (result.content.first() as TextContent).text.orEmpty()
+			assertTrue(text.contains("already exists"))
+			verify(client).listItems(query = eq("Hammer"), locationIds = anyOrNull(), pageSize = eq(50))
+			verify(client, never()).getLocationTree()
+			verify(client, never()).createItem(any(), any(), anyOrNull())
+		}
+
+	@Test
+	fun `returns error when location cannot be resolved`() =
+		runTest {
+			whenever(client.listItems(query = eq("Hammer"), locationIds = anyOrNull(), pageSize = eq(50)))
+				.thenReturn(emptyItemPage())
+			whenever(client.getLocationTree()).thenReturn(emptyList())
+
+			val result = tool.execute(
+				buildJsonObject {
+					put("name", JsonPrimitive("Hammer"))
+					put("location", JsonPrimitive("Unknown"))
+				},
+			)
+
+			val text = (result.content.first() as TextContent).text.orEmpty()
+			assertEquals("Location 'Unknown' was not found.", text)
+			verify(client).listItems(query = eq("Hammer"), locationIds = anyOrNull(), pageSize = eq(50))
+			verify(client).getLocationTree()
+			verify(client, never()).createItem(any(), any(), anyOrNull())
+		}
+
+	@Test
+	fun `creates item with default quantity when not provided`() =
+		runTest {
+			whenever(client.listItems(query = eq("Hammer"), locationIds = anyOrNull(), pageSize = eq(50)))
+				.thenReturn(emptyItemPage())
+			whenever(client.getLocationTree()).thenReturn(
+				listOf(
+					TreeItem(
+						id = "root",
+						name = "Home",
+						type = "location",
+						children = listOf(
+							TreeItem(
+								id = "garage",
+								name = "Garage",
+								type = "location",
+							),
+						),
+					),
+				),
+			)
+
+			whenever(
+				client.createItem(
+					name = eq("Hammer"),
+					locationId = eq("garage"),
+					description = anyOrNull(),
+				),
+			).thenReturn(
+				ItemSummary(
+					id = "created-id",
+					name = "Hammer",
+					description = null,
+					quantity = 1,
+					location = null,
+				),
+			)
+
+			val result = tool.execute(
+				buildJsonObject {
+					put("name", JsonPrimitive("Hammer"))
+					put("location", JsonPrimitive("home/garage"))
+				},
+			)
+
+			val text = (result.content.first() as TextContent).text.orEmpty()
+			assertTrue(text.contains("Created item \"Hammer\""))
+			assertTrue(text.contains("Home / Garage"))
+			assertTrue(text.contains("Quantity defaults to 1"))
+
+			verify(client).createItem(name = eq("Hammer"), locationId = eq("garage"), description = anyOrNull())
+			verify(client, never()).updateItemQuantity(any(), any())
+		}
+
+	@Test
+	fun `updates quantity when provided`() =
+		runTest {
+			whenever(client.listItems(query = eq("Screwdriver"), locationIds = anyOrNull(), pageSize = eq(50)))
+				.thenReturn(emptyItemPage())
+			whenever(client.getLocationTree()).thenReturn(
+				listOf(TreeItem(id = "drawer", name = "Drawer", type = "location")),
+			)
+			whenever(
+				client.createItem(
+					name = eq("Screwdriver"),
+					locationId = eq("drawer"),
+					description = anyOrNull(),
+				),
+			).thenReturn(
+				ItemSummary(
+					id = "item-123",
+					name = "Screwdriver",
+					description = null,
+					quantity = 1,
+					location = null,
+				),
+			)
+
+			val result = tool.execute(
+				buildJsonObject {
+					put("name", JsonPrimitive("Screwdriver"))
+					put("location", JsonPrimitive("drawer"))
+					put("quantity", JsonPrimitive(3))
+					put("description", JsonPrimitive("Flathead"))
+				},
+			)
+
+			val text = (result.content.first() as TextContent).text.orEmpty()
+			assertTrue(text.contains("Quantity set to 3"))
+
+			verify(client).updateItemQuantity("item-123", 3)
+		}
+
+	private fun emptyItemPage(): ItemPage = ItemPage(items = emptyList(), page = 1, pageSize = 50, total = 0)
+}

--- a/app/src/test/kotlin/com/homebox/mcp/ItemsResourceTest.kt
+++ b/app/src/test/kotlin/com/homebox/mcp/ItemsResourceTest.kt
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
@@ -136,7 +137,7 @@ class ItemsResourceTest {
 			val result = resource.read(request)
 
 			verify(client).getLocationTree()
-			verify(client, never()).listItems(any(), any())
+			verify(client, never()).listItems(anyOrNull(), anyOrNull(), any())
 
 			val contents = result.contents.single() as TextResourceContents
 			val payload = requireNotNull(contents.text)


### PR DESCRIPTION
## Summary
- extend the Homebox client with item creation, quantity updates, and item queries by name
- add an insert_item tool that validates inputs, resolves location paths, and prevents duplicate item names
- register the new tool on the server and cover its behavior with unit tests alongside updated resource tests

## Testing
- ./gradlew ktlintFormat --console=plain
- ./gradlew check --parallel --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68efcdc903308332863c7efc4a727424