### PR TITLE
Generate MCP tool schemas from Kotlin models

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -12,6 +12,7 @@ dependencies {
 	implementation(libs.kotlinx.coroutines.core)
 	implementation(libs.kotlinx.serialization.json)
 	implementation(libs.mcp.sdk)
+	implementation(libs.xemantic.ai.tool.schema)
 	implementation(libs.ktor.client.core)
 	implementation(libs.ktor.client.cio)
 	implementation(libs.ktor.client.content.negotiation)

--- a/app/src/main/kotlin/com/homebox/mcp/CreateLocationTool.kt
+++ b/app/src/main/kotlin/com/homebox/mcp/CreateLocationTool.kt
@@ -1,65 +1,48 @@
 package com.homebox.mcp
 
+import com.xemantic.ai.tool.schema.generator.jsonSchemaOf
+import com.xemantic.ai.tool.schema.meta.Description
 import io.modelcontextprotocol.kotlin.sdk.CallToolResult
 import io.modelcontextprotocol.kotlin.sdk.TextContent
 import io.modelcontextprotocol.kotlin.sdk.Tool
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.MissingFieldException
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
-import kotlinx.serialization.json.buildJsonObject
-import kotlinx.serialization.json.contentOrNull
-import kotlinx.serialization.json.jsonPrimitive
-import kotlinx.serialization.json.put
 
 class CreateLocationTool(private val client: HomeboxClient) {
 	val name: String = "create_location"
 	val description: String =
 		"Create a Homebox location. Provide a single name or a slash-separated path to create nested locations, reusing existing parents when present."
 
-	val inputSchema: Tool.Input = Tool.Input(
-		properties = buildJsonObject {
-			put(
-				"path",
-				buildJsonObject {
-					put("type", "string")
-					put(
-						"description",
-						"The location name or a '/' separated path (e.g., 'Home/Basement/Shelf A'). Matching is case-insensitive and preserves spaces.",
-					)
-				},
-			)
-			put(
-				"description",
-				buildJsonObject {
-					put("type", "string")
-					put(
-						"description",
-						"Optional description applied to the final location created in the path.",
-					)
-				},
-			)
-		},
-		required = listOf("path"),
-	)
+	val inputSchema: Tool.Input = SCHEMA
 
+	@OptIn(ExperimentalSerializationApi::class)
 	suspend fun execute(arguments: JsonObject): CallToolResult {
-		val rawPath = arguments["path"]?.jsonPrimitive?.contentOrNull?.trim()
-		if (rawPath.isNullOrBlank()) {
-			return CallToolResult(content = listOf(TextContent("Path is required to create a location.")))
+		val input = try {
+			json.decodeFromJsonElement(Parameters.serializer(), arguments)
+		} catch (missing: MissingFieldException) {
+			return errorResult("Path is required to create a location.")
+		} catch (serialization: SerializationException) {
+			return errorResult(
+				"Invalid arguments for create_location tool: ${serialization.message ?: "serialization error"}",
+			)
 		}
 
-		val description = arguments["description"]
-			?.jsonPrimitive
-			?.contentOrNull
-			?.trim()
-			?.takeIf { it.isNotEmpty() }
+		val rawPath = input.path.trim()
+		if (rawPath.isEmpty()) {
+			return errorResult("Path is required to create a location.")
+		}
 
+		val description = input.description?.trim()?.takeIf { it.isNotEmpty() }
 		val segments = rawPath
 			.split('/')
 			.map { it.trim() }
 			.filter { it.isNotEmpty() }
 		if (segments.isEmpty()) {
-			return CallToolResult(
-				content = listOf(TextContent("Path must include at least one non-empty location segment.")),
-			)
+			return errorResult("Path must include at least one non-empty location segment.")
 		}
 
 		val tree = client.getLocationTree()
@@ -106,6 +89,8 @@ class CreateLocationTool(private val client: HomeboxClient) {
 		return CallToolResult(content = listOf(TextContent(message)))
 	}
 
+	private fun errorResult(message: String): CallToolResult = CallToolResult(content = listOf(TextContent(message)))
+
 	private fun List<TreeItem>.filterLocations(): List<TreeItem> = filter { it.type.equals(LOCATION_TYPE, ignoreCase = true) }
 
 	private fun MutableMap<String?, MutableMap<String, KnownLocation>>.ensureParentChildren(parentId: String?, children: List<TreeItem>) {
@@ -138,11 +123,26 @@ class CreateLocationTool(private val client: HomeboxClient) {
 
 	private companion object {
 		private const val LOCATION_TYPE = "location"
+
+		private val json = Json {
+			ignoreUnknownKeys = true
+		}
+
+		private val SCHEMA: Tool.Input = jsonSchemaOf<Parameters>().toToolInput()
 	}
 
 	private data class KnownLocation(
 		val id: String,
 		val name: String,
 		val children: List<TreeItem>,
+	)
+
+	@Serializable
+	@Description("Parameters for the create_location tool")
+	private data class Parameters(
+		@Description("The location name or a '/' separated path (e.g., 'Home/Basement/Shelf A'). Matching is case-insensitive and preserves spaces.")
+		val path: String,
+		@Description("Optional description applied to the final location created in the path.")
+		val description: String? = null,
 	)
 }

--- a/app/src/main/kotlin/com/homebox/mcp/ToolSchemas.kt
+++ b/app/src/main/kotlin/com/homebox/mcp/ToolSchemas.kt
@@ -1,0 +1,22 @@
+package com.homebox.mcp
+
+import com.xemantic.ai.tool.schema.JsonSchema
+import com.xemantic.ai.tool.schema.serialization.JsonSchemaSerializer
+import io.modelcontextprotocol.kotlin.sdk.Tool
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
+private val schemaJson = Json {
+	prettyPrint = false
+}
+
+internal fun JsonSchema.toToolInput(): Tool.Input {
+	val schema = schemaJson.encodeToJsonElement(JsonSchemaSerializer, this).jsonObject
+	val properties = schema["properties"]?.jsonObject ?: JsonObject(emptyMap())
+	val required = schema["required"]?.jsonArray?.map { it.jsonPrimitive.content }
+
+	return Tool.Input(properties = properties, required = required)
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,6 +9,7 @@ kotlinx-serialization = "1.9.0"
 mcp = "0.7.2"
 mockito = "5.20.0"
 mockito-kotlin = "6.1.0"
+xemantic-ai-tool-schema = "1.2.0"
 
 [libraries]
 ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
@@ -22,6 +23,7 @@ kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-t
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization" }
 
 mcp-sdk = { module = "io.modelcontextprotocol:kotlin-sdk", version.ref = "mcp" }
+xemantic-ai-tool-schema = { module = "com.xemantic.ai:xemantic-ai-tool-schema-jvm", version.ref = "xemantic-ai-tool-schema" }
 
 mockito-core = { module = "org.mockito:mockito-core", version.ref = "mockito" }
 mockito-kotlin = { module = "org.mockito.kotlin:mockito-kotlin", version.ref = "mockito-kotlin" }


### PR DESCRIPTION
## Summary
- add the xemantic-ai-tool-schema 1.2.0 dependency
- define serializable tool parameter models and generate schemas from them
- decode tool arguments with kotlinx serialization and share a helper to turn schemas into MCP tool inputs

## Testing
- ./gradlew check --parallel --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68f6b7fc894c8332bcb1d006b0f8810a