### PR TITLE
Fix UUID serialization for Homebox client requests

### DIFF
--- a/app/src/main/kotlin/com/homebox/mcp/CreateLocationTool.kt
+++ b/app/src/main/kotlin/com/homebox/mcp/CreateLocationTool.kt
@@ -5,9 +5,12 @@ import com.xemantic.ai.tool.schema.meta.Title
 import dev.forkhandles.result4k.onFailure
 import io.modelcontextprotocol.kotlin.sdk.CallToolResult
 import io.modelcontextprotocol.kotlin.sdk.Tool
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonObject
 
+@OptIn(ExperimentalUuidApi::class)
 class CreateLocationTool(private val client: HomeboxClient) {
 	val name: String = "create_location"
 	val description: String =
@@ -75,7 +78,7 @@ class CreateLocationTool(private val client: HomeboxClient) {
 	)
 
 	private data class KnownLocation(
-		val id: String?,
+		val id: Uuid?,
 		val children: List<TreeItem>,
 	)
 }

--- a/app/src/main/kotlin/com/homebox/mcp/HomeboxClient.kt
+++ b/app/src/main/kotlin/com/homebox/mcp/HomeboxClient.kt
@@ -1,3 +1,6 @@
+@file:OptIn(ExperimentalUuidApi::class)
+@file:UseSerializers(UuidAsStringSerializer::class)
+
 package com.homebox.mcp
 
 import io.ktor.client.HttpClient
@@ -11,11 +14,21 @@ import io.ktor.client.request.setBody
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
+import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.UseSerializers
 import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.json.Json
 
+@OptIn(ExperimentalUuidApi::class)
 class HomeboxClient(
 	private val httpClient: HttpClient,
 	private val baseUrl: String,
@@ -53,7 +66,7 @@ class HomeboxClient(
 
 	suspend fun createLocation(
 		name: String,
-		parentId: String? = null,
+		parentId: Uuid? = null,
 		description: String? = null,
 	): LocationSummary {
 		require(name.isNotBlank()) { "Location name must not be blank" }
@@ -61,7 +74,13 @@ class HomeboxClient(
 			accept(ContentType.Application.Json)
 			header(HttpHeaders.ContentType, ContentType.Application.Json)
 			header(HttpHeaders.Authorization, "Bearer $apiToken")
-			setBody(LocationCreateRequest(name = name, description = description, parentId = parentId))
+			setBody(
+				LocationCreateRequest(
+					name = name,
+					description = description,
+					parentId = parentId,
+				),
+			)
 		}
 
 		return json.decodeFromString<LocationSummary>(response.bodyAsText())
@@ -69,13 +88,13 @@ class HomeboxClient(
 
 	suspend fun listItems(
 		query: String? = null,
-		locationIds: List<String>? = null,
+		locationIds: List<Uuid>? = null,
 		pageSize: Int = 100,
 	): ItemPage {
 		val response = httpClient.get("$baseUrl/v1/items") {
 			parameter("pageSize", pageSize)
 			query?.takeIf { it.isNotBlank() }?.let { parameter("q", it) }
-			locationIds?.forEach { parameter("locations", it) }
+			locationIds?.forEach { parameter("locations", it.toString()) }
 			accept(ContentType.Application.Json)
 			header(HttpHeaders.Authorization, "Bearer $apiToken")
 		}
@@ -86,26 +105,29 @@ class HomeboxClient(
 
 	suspend fun createItem(
 		name: String,
-		locationId: String,
+		locationId: Uuid,
 		description: String? = null,
 	): ItemSummary {
 		require(name.isNotBlank()) { "Item name must not be blank" }
-		require(locationId.isNotBlank()) { "Location ID must not be blank" }
 
 		val response = httpClient.post("$baseUrl/v1/items") {
 			accept(ContentType.Application.Json)
 			header(HttpHeaders.ContentType, ContentType.Application.Json)
 			header(HttpHeaders.Authorization, "Bearer $apiToken")
-			setBody(ItemCreateRequest(name = name, description = description, locationId = locationId))
+			setBody(
+				ItemCreateRequest(
+					name = name,
+					description = description,
+					locationId = locationId,
+				),
+			)
 		}
 
 		val payload = response.bodyAsText()
 		return json.decodeFromString(ItemSummary.serializer(), payload)
 	}
 
-	suspend fun updateItemQuantity(id: String, quantity: Int) {
-		require(id.isNotBlank()) { "Item ID must not be blank" }
-
+	suspend fun updateItemQuantity(id: Uuid, quantity: Int) {
 		httpClient.patch("$baseUrl/v1/items/$id") {
 			accept(ContentType.Application.Json)
 			header(HttpHeaders.ContentType, ContentType.Application.Json)
@@ -114,7 +136,7 @@ class HomeboxClient(
 		}
 	}
 
-	suspend fun getLocation(id: String): LocationDetails {
+	suspend fun getLocation(id: Uuid): LocationDetails {
 		val response = httpClient.get("$baseUrl/v1/locations/$id") {
 			accept(ContentType.Application.Json)
 			header(HttpHeaders.Authorization, "Bearer $apiToken")
@@ -132,7 +154,7 @@ class HomeboxClient(
 
 @Serializable
 data class Location(
-	val id: String,
+	val id: Uuid,
 	val name: String,
 	val description: String? = null,
 	@SerialName("itemCount") val itemCount: Int? = null,
@@ -140,14 +162,14 @@ data class Location(
 
 @Serializable
 data class LocationSummary(
-	val id: String,
+	val id: Uuid,
 	val name: String,
 	val description: String? = null,
 )
 
 @Serializable
 data class TreeItem(
-	val id: String,
+	val id: Uuid,
 	val name: String,
 	val type: TreeItemType,
 	val children: List<TreeItem> = emptyList(),
@@ -166,14 +188,14 @@ enum class TreeItemType {
 private data class LocationCreateRequest(
 	val name: String,
 	val description: String? = null,
-	val parentId: String? = null,
+	val parentId: Uuid? = null,
 )
 
 @Serializable
 private data class ItemCreateRequest(
 	val name: String,
 	val description: String? = null,
-	val locationId: String,
+	val locationId: Uuid,
 )
 
 @Serializable
@@ -183,7 +205,7 @@ private data class ItemPatchRequest(
 
 @Serializable
 data class ItemSummary(
-	val id: String,
+	val id: Uuid,
 	val name: String,
 	val description: String? = null,
 	val quantity: Int? = null,
@@ -200,8 +222,19 @@ data class ItemPage(
 
 @Serializable
 data class LocationDetails(
-	val id: String,
+	val id: Uuid,
 	val name: String,
 	val description: String? = null,
 	val parent: LocationSummary? = null,
 )
+
+@OptIn(ExperimentalUuidApi::class)
+object UuidAsStringSerializer : KSerializer<Uuid> {
+	override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("Uuid", PrimitiveKind.STRING)
+
+	override fun serialize(encoder: Encoder, value: Uuid) {
+		encoder.encodeString(value.toString())
+	}
+
+	override fun deserialize(decoder: Decoder): Uuid = Uuid.parse(decoder.decodeString())
+}

--- a/app/src/main/kotlin/com/homebox/mcp/InsertItemTool.kt
+++ b/app/src/main/kotlin/com/homebox/mcp/InsertItemTool.kt
@@ -7,10 +7,12 @@ import dev.forkhandles.result4k.onFailure
 import io.modelcontextprotocol.kotlin.sdk.CallToolResult
 import io.modelcontextprotocol.kotlin.sdk.TextContent
 import io.modelcontextprotocol.kotlin.sdk.Tool
+import kotlin.uuid.ExperimentalUuidApi
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonObject
 
+@OptIn(ExperimentalUuidApi::class)
 class InsertItemTool(private val client: HomeboxClient) {
 	val name: String = "insert_item"
 	val description: String =

--- a/app/src/main/kotlin/com/homebox/mcp/LocationResolver.kt
+++ b/app/src/main/kotlin/com/homebox/mcp/LocationResolver.kt
@@ -26,7 +26,7 @@ class LocationResolver(private val tree: List<TreeItem>) {
 		return ResolvedLocation(id, segments)
 	}
 
-	private fun resolve(segments: List<String>, currentNodes: List<TreeItem>): String? {
+	private fun resolve(segments: List<String>, currentNodes: List<TreeItem>): Uuid? {
 		val node = currentNodes
 			.filter { it.type == TreeItemType.LOCATION }
 			.find { it.name.equals(segments[0], ignoreCase = true) } ?: return null
@@ -42,7 +42,7 @@ class LocationResolver(private val tree: List<TreeItem>) {
 		nodes
 			.filter { it.type == TreeItemType.LOCATION }
 			.forEach { node ->
-				if (node.id == id.toString()) {
+				if (node.id == id) {
 					return ResolvedLocation(node.id, listOf(node.name))
 				}
 				val foundChild = resolveById(id, node.children)
@@ -53,5 +53,5 @@ class LocationResolver(private val tree: List<TreeItem>) {
 		return null
 	}
 
-	data class ResolvedLocation(val id: String, val path: List<String>)
+	data class ResolvedLocation(val id: Uuid, val path: List<String>)
 }

--- a/app/src/test/kotlin/com/homebox/mcp/HomeboxClientTest.kt
+++ b/app/src/test/kotlin/com/homebox/mcp/HomeboxClientTest.kt
@@ -12,6 +12,7 @@ import io.ktor.http.Url
 import io.ktor.http.headersOf
 import io.ktor.serialization.kotlinx.json.json
 import io.ktor.utils.io.ByteReadChannel
+import kotlin.uuid.ExperimentalUuidApi
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
@@ -19,17 +20,18 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
 
-@OptIn(ExperimentalCoroutinesApi::class)
+@OptIn(ExperimentalCoroutinesApi::class, ExperimentalUuidApi::class)
 class HomeboxClientTest {
 	@Test
 	fun `listLocations requests and parses response`() =
 		runTest {
 			var capturedRequest: HttpRequestData? = null
+			val locationId = TestConstants.TEST_ID_1
 			val engine = MockEngine { request ->
 				capturedRequest = request
 				respond(
 					content = ByteReadChannel(
-						"""[{"id":"1","name":"Kitchen","itemCount":4}]""",
+						"""[{"id":"$locationId","name":"Kitchen","itemCount":4}]""",
 					),
 					status = HttpStatusCode.OK,
 					headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString()),
@@ -102,11 +104,13 @@ class HomeboxClientTest {
 	fun `listItems requests and parses response`() =
 		runTest {
 			var capturedRequest: HttpRequestData? = null
+			val itemId = TestConstants.TEST_ID_1
+			val locationId = TestConstants.TEST_ID_2
 			val engine = MockEngine { request ->
 				capturedRequest = request
 				respond(
 					content = ByteReadChannel(
-"""{"items":[{"id":"item-1","name":"Hammer","quantity":2,"description":"Steel","location":{"id":"loc-1","name":"Shelf A"}}],"page":1,"pageSize":100,"total":1}""",
+"""{"items":[{"id":"$itemId","name":"Hammer","quantity":2,"description":"Steel","location":{"id":"$locationId","name":"Shelf A"}}],"page":1,"pageSize":100,"total":1}""",
 					),
 					status = HttpStatusCode.OK,
 					headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString()),
@@ -147,20 +151,26 @@ class HomeboxClientTest {
 			val httpClient = HttpClient(engine)
 			val client = HomeboxClient(httpClient, "https://example.test", "token")
 
-			client.listItems(locationIds = listOf("loc-1", "loc-2"))
+			val locationId1 = TestConstants.TEST_ID_1
+			val locationId2 = TestConstants.TEST_ID_2
+			client.listItems(locationIds = listOf(locationId1, locationId2))
 
 			val url = requireNotNull(capturedUrl)
-			assertEquals(listOf("loc-1", "loc-2"), url.parameters.getAll("locations"))
+			assertEquals(listOf(locationId1.toString(), locationId2.toString()), url.parameters.getAll("locations"))
 		}
 
 	@Test
 	fun `getLocation fetches details`() =
 		runTest {
 			var capturedRequest: HttpRequestData? = null
+			val locationId = TestConstants.TEST_ID_1
+			val parentId = TestConstants.TEST_ID_2
 			val engine = MockEngine { request ->
 				capturedRequest = request
 				respond(
-					content = ByteReadChannel("""{"id":"loc-1","name":"Shelf A","parent":{"id":"root","name":"Home"}}"""),
+					content = ByteReadChannel(
+						"""{"id":"$locationId","name":"Shelf A","parent":{"id":"$parentId","name":"Home"}}""",
+					),
 					status = HttpStatusCode.OK,
 					headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString()),
 				)
@@ -169,12 +179,12 @@ class HomeboxClientTest {
 			val httpClient = HttpClient(engine)
 			val client = HomeboxClient(httpClient, "https://example.test", "token")
 
-			val location = client.getLocation("loc-1")
+			val location = client.getLocation(locationId)
 
 			val request = requireNotNull(capturedRequest)
-			assertEquals("/v1/locations/loc-1", request.url.encodedPath)
+			assertEquals("/v1/locations/$locationId", request.url.encodedPath)
 			assertEquals("Shelf A", location.name)
-			assertEquals("root", location.parent?.id)
+			assertEquals(parentId, location.parent?.id)
 		}
 
 	@Test

--- a/app/src/test/kotlin/com/homebox/mcp/ItemsResourceTest.kt
+++ b/app/src/test/kotlin/com/homebox/mcp/ItemsResourceTest.kt
@@ -2,6 +2,8 @@ package com.homebox.mcp
 
 import io.modelcontextprotocol.kotlin.sdk.ReadResourceRequest
 import io.modelcontextprotocol.kotlin.sdk.TextResourceContents
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
@@ -21,7 +23,7 @@ import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
-@OptIn(ExperimentalCoroutinesApi::class)
+@OptIn(ExperimentalCoroutinesApi::class, ExperimentalUuidApi::class)
 class ItemsResourceTest {
 	private val client: HomeboxClient = mock()
 	private val resource = ItemsResource(client)
@@ -29,22 +31,25 @@ class ItemsResourceTest {
 	@Test
 	fun `read without query returns items with cached location paths`() =
 		runTest {
+			val locationId = TestConstants.TEST_ID_1
+			val parentId = TestConstants.TEST_ID_2
+			val rootId = TestConstants.TEST_ID_3
 			whenever(client.listItems(locationIds = null, pageSize = 100)).thenReturn(
 				ItemPage(
 					items = listOf(
 						ItemSummary(
-							id = "item-1",
+							id = TestConstants.TEST_ID_4,
 							name = "Hammer",
 							description = "Steel hammer",
 							quantity = 2,
-							location = LocationSummary(id = "loc-1", name = "Shelf A"),
+							location = LocationSummary(id = locationId, name = "Shelf A"),
 						),
 						ItemSummary(
-							id = "item-2",
+							id = TestConstants.TEST_ID_5,
 							name = "Nails",
 							description = null,
 							quantity = 100,
-							location = LocationSummary(id = "loc-1", name = "Shelf A"),
+							location = LocationSummary(id = locationId, name = "Shelf A"),
 						),
 					),
 					page = 1,
@@ -52,20 +57,30 @@ class ItemsResourceTest {
 					total = 150,
 				),
 			)
-			whenever(client.getLocation("loc-1")).thenReturn(
-				LocationDetails(id = "loc-1", name = "Shelf A", parent = LocationSummary(id = "loc-0", name = "Basement")),
+			whenever(client.getLocation(locationId)).thenReturn(
+				LocationDetails(
+					id = locationId,
+					name = "Shelf A",
+					parent = LocationSummary(id = parentId, name = "Basement"),
+				),
 			)
-			whenever(client.getLocation("loc-0")).thenReturn(
-				LocationDetails(id = "loc-0", name = "Basement", parent = LocationSummary(id = "root", name = "Home")),
+			whenever(client.getLocation(parentId)).thenReturn(
+				LocationDetails(
+					id = parentId,
+					name = "Basement",
+					parent = LocationSummary(id = rootId, name = "Home"),
+				),
 			)
-			whenever(client.getLocation("root")).thenReturn(LocationDetails(id = "root", name = "Home", parent = null))
+			whenever(client.getLocation(rootId)).thenReturn(
+				LocationDetails(id = rootId, name = "Home", parent = null),
+			)
 
 			val result = resource.read(ReadResourceRequest("resource://homebox/items", buildJsonObject { }))
 
 			verify(client).listItems(locationIds = null, pageSize = 100)
-			verify(client).getLocation("loc-1")
-			verify(client).getLocation("loc-0")
-			verify(client).getLocation("root")
+			verify(client).getLocation(locationId)
+			verify(client).getLocation(parentId)
+			verify(client).getLocation(rootId)
 
 			val contents = result.contents.single() as TextResourceContents
 			val payload = requireNotNull(contents.text)
@@ -81,25 +96,33 @@ class ItemsResourceTest {
 	@Test
 	fun `read with location path query filters items`() =
 		runTest {
+			val rootId = TestConstants.TEST_ID_1
+			val basementId = TestConstants.TEST_ID_2
 			whenever(client.getLocationTree()).thenReturn(
 				listOf(
 					TreeItem(
-						id = "root",
+						id = rootId,
 						name = "Home",
 						type = TreeItemType.LOCATION,
-						children = listOf(TreeItem(id = "loc-2", name = "Basement", type = TreeItemType.LOCATION)),
+						children = listOf(
+							TreeItem(
+								id = basementId,
+								name = "Basement",
+								type = TreeItemType.LOCATION,
+							),
+						),
 					),
 				),
 			)
-			whenever(client.listItems(locationIds = listOf("loc-2"), pageSize = 100)).thenReturn(
+			whenever(client.listItems(locationIds = listOf(basementId), pageSize = 100)).thenReturn(
 				ItemPage(
 					items = listOf(
 						ItemSummary(
-							id = "item-3",
+							id = TestConstants.TEST_ID_3,
 							name = "Drill",
 							description = null,
 							quantity = 1,
-							location = LocationSummary(id = "loc-2", name = "Basement"),
+							location = LocationSummary(id = basementId, name = "Basement"),
 						),
 					),
 					page = 1,
@@ -107,14 +130,22 @@ class ItemsResourceTest {
 					total = 1,
 				),
 			)
-			whenever(client.getLocation("loc-2")).thenReturn(LocationDetails(id = "loc-2", name = "Basement", parent = LocationSummary(id = "root", name = "Home")))
-			whenever(client.getLocation("root")).thenReturn(LocationDetails(id = "root", name = "Home", parent = null))
+			whenever(client.getLocation(basementId)).thenReturn(
+				LocationDetails(
+					id = basementId,
+					name = "Basement",
+					parent = LocationSummary(id = rootId, name = "Home"),
+				),
+			)
+			whenever(client.getLocation(rootId)).thenReturn(
+				LocationDetails(id = rootId, name = "Home", parent = null),
+			)
 
 			val request = ReadResourceRequest("resource://homebox/items?location=Home/Basement", buildJsonObject { })
 			val result = resource.read(request)
 
 			verify(client).getLocationTree()
-			verify(client).listItems(locationIds = listOf("loc-2"), pageSize = 100)
+			verify(client).listItems(locationIds = listOf(basementId), pageSize = 100)
 
 			val contents = result.contents.single() as TextResourceContents
 			val payload = requireNotNull(contents.text)
@@ -130,14 +161,14 @@ class ItemsResourceTest {
 	fun `read with unmatched location returns empty set`() =
 		runTest {
 			whenever(client.getLocationTree()).thenReturn(
-				listOf(TreeItem(id = "root", name = "Home", type = TreeItemType.LOCATION)),
+				listOf(TreeItem(id = TestConstants.TEST_ID_1, name = "Home", type = TreeItemType.LOCATION)),
 			)
 
 			val request = ReadResourceRequest("resource://homebox/items?location=Unknown", buildJsonObject { })
 			val result = resource.read(request)
 
 			verify(client).getLocationTree()
-			verify(client, never()).listItems(anyOrNull(), anyOrNull(), any())
+			verify(client, never()).listItems(anyOrNull(), anyOrNull<List<Uuid>>(), any())
 
 			val contents = result.contents.single() as TextResourceContents
 			val payload = requireNotNull(contents.text)

--- a/app/src/test/kotlin/com/homebox/mcp/LocationResolverTest.kt
+++ b/app/src/test/kotlin/com/homebox/mcp/LocationResolverTest.kt
@@ -10,29 +10,29 @@ import org.junit.jupiter.api.Test
 class LocationResolverTest {
 	private val tree = listOf(
 		TreeItem(
-			id = TestConstants.TEST_ID_1.toString(),
+			id = TestConstants.TEST_ID_1,
 			name = "Home",
 			type = TreeItemType.LOCATION,
 			children = listOf(
 				TreeItem(
-					id = TestConstants.TEST_ID_2.toString(),
+					id = TestConstants.TEST_ID_2,
 					name = "Garage",
 					type = TreeItemType.LOCATION,
 					children = listOf(
 						TreeItem(
-							id = TestConstants.TEST_ID_3.toString(),
+							id = TestConstants.TEST_ID_3,
 							name = "Shelf A",
 							type = TreeItemType.LOCATION,
 						),
 					),
 				),
 				TreeItem(
-					id = TestConstants.TEST_ID_4.toString(),
+					id = TestConstants.TEST_ID_4,
 					name = "Attic",
 					type = TreeItemType.LOCATION,
 				),
 				TreeItem(
-					id = TestConstants.TEST_ID_5.toString(),
+					id = TestConstants.TEST_ID_5,
 					name = "Old Lamp",
 					type = TreeItemType.ITEM,
 				),
@@ -47,7 +47,7 @@ class LocationResolverTest {
 		val result = resolver.resolve(TestConstants.TEST_ID_4.toString())
 
 		assertNotNull(result)
-		assertEquals(TestConstants.TEST_ID_4.toString(), result!!.id)
+		assertEquals(TestConstants.TEST_ID_4, result!!.id)
 		assertEquals(listOf("Home", "Attic"), result.path)
 	}
 
@@ -56,7 +56,7 @@ class LocationResolverTest {
 		val result = resolver.resolve("home/garage/shelf a")
 
 		assertNotNull(result)
-		assertEquals(TestConstants.TEST_ID_3.toString(), result!!.id)
+		assertEquals(TestConstants.TEST_ID_3, result!!.id)
 	}
 
 	@Test

--- a/app/src/test/kotlin/com/homebox/mcp/LocationsResourceTest.kt
+++ b/app/src/test/kotlin/com/homebox/mcp/LocationsResourceTest.kt
@@ -1,6 +1,7 @@
 package com.homebox.mcp
 
 import io.modelcontextprotocol.kotlin.sdk.TextResourceContents
+import kotlin.uuid.ExperimentalUuidApi
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
@@ -15,7 +16,7 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
-@OptIn(ExperimentalCoroutinesApi::class)
+@OptIn(ExperimentalCoroutinesApi::class, ExperimentalUuidApi::class)
 class LocationsResourceTest {
 	private val client: HomeboxClient = mock()
 	private val resource = LocationsResource(client)
@@ -26,18 +27,18 @@ class LocationsResourceTest {
 			whenever(client.getLocationTree(withItems = true)).thenReturn(
 				listOf(
 					TreeItem(
-						id = "loc-1",
+						id = TestConstants.TEST_ID_1,
 						name = "Kitchen",
 						type = TreeItemType.LOCATION,
 						children = listOf(
-							TreeItem(id = "item-1", name = "Plate", type = TreeItemType.ITEM),
+							TreeItem(id = TestConstants.TEST_ID_2, name = "Plate", type = TreeItemType.ITEM),
 							TreeItem(
-								id = "loc-2",
+								id = TestConstants.TEST_ID_3,
 								name = "Pantry",
 								type = TreeItemType.LOCATION,
 								children = listOf(
-									TreeItem(id = "item-2", name = "Flour", type = TreeItemType.ITEM),
-									TreeItem(id = "item-3", name = "Sugar", type = TreeItemType.ITEM),
+									TreeItem(id = TestConstants.TEST_ID_4, name = "Flour", type = TreeItemType.ITEM),
+									TreeItem(id = TestConstants.TEST_ID_5, name = "Sugar", type = TreeItemType.ITEM),
 								),
 							),
 						),


### PR DESCRIPTION
## Summary
- register a kotlinx serializer so Homebox client requests and responses encode kotlin.uuid.Uuid values directly
- update location and item creation payloads to send and receive raw Uuid values instead of strings
- simplify Homebox client tests to use shared TestConstants without redundant string copies

## Testing
- ./gradlew ktlintFormat --console=plain
- ./gradlew check --parallel --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68f7e7870b5c83329a894310d564d662